### PR TITLE
Clarify the key-value pair for the dependent_fields docs.

### DIFF
--- a/docs/extra.rst
+++ b/docs/extra.rst
@@ -27,10 +27,11 @@ Here are our two models:
 Customizing a Form
 ``````````````````
 
-Lets link two widgets via *dependent_fields*.
+Lets link two widgets via a *dependent_fields* dictionary. The key represents the name of 
+the field in the form. The value represents the name of the field in the model (used in `queryset`).
 
 .. code-block:: python
-    :emphasize-lines: 15
+    :emphasize-lines: 17
 
     class AddressForm(forms.Form):
         country = forms.ModelChoiceField(


### PR DESCRIPTION
Thanks for maintaining django-select2! 

I was confused by the `dependent_fields` documentation until I found the implementation in the code. This PR pulls the description of the `dependent_fields` key-value pair from the `HeavySelect2Mixin` docstring.

It also fixes the emphasis to be the correct line.