### PR TITLE
Fix incorrect syntax in doctstring example

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -178,7 +178,7 @@ class Select2TagWidget(Select2TagMixin, Select2Mixin, forms.SelectMultiple):
         class MyWidget(Select2TagWidget):
 
             def value_from_datadict(self, data, files, name):
-                values = super().value_from_datadict(data, files, name):
+                values = super().value_from_datadict(data, files, name)
                 return ",".join(values)
 
             def optgroups(self, name, value, attrs=None):


### PR DESCRIPTION
Assignments should usually not be followed by a colon. :wink: 