### PR TITLE
Try to match dependent fields also with ends-with jquery to support nested forms/inlines

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -28,7 +28,12 @@
           if (dependentFields) {
             dependentFields = dependentFields.trim().split(/\s+/)
             $.each(dependentFields, function (i, dependentField) {
-              result[dependentField] = $('[name=' + dependentField + ']', $element.closest('form')).val()
+              var tmpres = $('[name=' + dependentField + ']', $element.closest('form')).val()
+              if (!tmpres) { // If dependendent field not found, maybe it is a nested form, we try to match with ends with -name
+                result[dependentField] = $('[name$=-' + dependentField + ']', $element.closest('form')).val()
+              } else {
+                result[dependentField] = tmpres
+              }
             })
           }
 


### PR DESCRIPTION
When using forms with nested fields or inlines, the form id does not match the field, with this fix, if the exact field name does not match, we try to match a field ending with the name preceded with "-" (django separates the form/inlines/fields with -