### PR TITLE
Remove colon in example for use with ArrayField

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -178,7 +178,7 @@ class Select2TagWidget(Select2TagMixin, Select2Mixin, forms.SelectMultiple):
         class MyWidget(Select2TagWidget):
 
             def value_from_datadict(self, data, files, name):
-                values = super().value_from_datadict(data, files, name):
+                values = super().value_from_datadict(data, files, name)
                 return ",".join(values)
 
             def optgroups(self, name, value, attrs=None):


### PR DESCRIPTION
Example was using invalid syntax:

```
    values = super().value_from_datadict(data, files, name):
                                                           ^
SyntaxError: invalid syntax
```