### PR TITLE
Allow django_select2.js to be to be hosted elsewhere

### DIFF
--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -56,6 +56,17 @@ class Select2Conf(AppConf):
     It has set `select2_` as a default value, which you can change if needed.
     """
 
+    DJANGO_SELECT2_JS = 'static/django_select2/django_select2.js'
+    """
+        The URI for the django_select2 JS file. By default this points to the local 'static'
+        resources.
+
+        If you provide your own JS and would not like Django-Select2 to load any, change
+        this setting to a blank string like so::
+
+            SELECT2_DJANGO_SELECT2_JS = ''
+        """
+
     JS = "https://cdnjs.cloudflare.com/ajax/libs/select2/{version}/js/select2.min.js".format(
         version=LIB_VERSION
     )

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -108,6 +108,8 @@ class Select2Mixin:
         lang = get_language()
         select2_js = (settings.SELECT2_JS,) if settings.SELECT2_JS else ()
         select2_css = (settings.SELECT2_CSS,) if settings.SELECT2_CSS else ()
+        django_select2_js = (
+            settings.SELECT2_DJANGO_SELECT2_JS, ) if settings.SELECT2_DJANGO_SELECT2_JS else ()
 
         i18n_name = SELECT2_TRANSLATIONS.get(lang)
         if i18n_name not in settings.SELECT2_I18N_AVAILABLE_LANGUAGES:
@@ -118,7 +120,7 @@ class Select2Mixin:
         )
 
         return forms.Media(
-            js=select2_js + i18n_file + ("django_select2/django_select2.js",),
+            js=select2_js + i18n_file + django_select2_js,
             css={"screen": select2_css},
         )
 


### PR DESCRIPTION
I ran into an issue where because my jquery is being bundled by webpack the default handling of django_select2.js does pick up my jquery installation.

This allows us to simply host django_select2.js elsewhere and avoid console errors