### PR TITLE
Fix to work with startswith filter

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -446,6 +446,52 @@ class TestModelSelect2Mixin(TestHeavySelect2Mixin):
         )
         assert qs.exists()
 
+    def test_filter_queryset__startswith(self, genres):
+        genre = Genre.objects.create(title="Space Genre")
+        widget = TitleModelSelect2Widget(queryset=Genre.objects.all())
+        assert widget.filter_queryset(None, genre.title).exists()
+
+        widget = TitleModelSelect2Widget(
+            search_fields=["title__istartswith"], queryset=Genre.objects.all()
+        )
+        qs = widget.filter_queryset(None, "Space Gen")
+        assert qs.exists()
+
+        qs = widget.filter_queryset(None, "Gen")
+        assert not qs.exists()
+
+    def test_filter_queryset__contains(self, genres):
+        genre = Genre.objects.create(title="Space Genre")
+        widget = TitleModelSelect2Widget(queryset=Genre.objects.all())
+        assert widget.filter_queryset(None, genre.title).exists()
+
+        widget = TitleModelSelect2Widget(
+            search_fields=["title__contains"], queryset=Genre.objects.all()
+        )
+        qs = widget.filter_queryset(None, "Space Gen")
+        assert qs.exists()
+
+        qs = widget.filter_queryset(None, "NOT Gen")
+        assert qs.exists(), "contains works even if only one part matches"
+
+    def test_filter_queryset__multiple_fields(self, genres):
+        genre = Genre.objects.create(title="Space Genre")
+        widget = TitleModelSelect2Widget(queryset=Genre.objects.all())
+        assert widget.filter_queryset(None, genre.title).exists()
+
+        widget = TitleModelSelect2Widget(
+            search_fields=[
+                "title__startswith",
+                "title__endswith",
+            ],
+            queryset=Genre.objects.all(),
+        )
+        qs = widget.filter_queryset(None, "Space")
+        assert qs.exists()
+
+        qs = widget.filter_queryset(None, "Genre")
+        assert qs.exists()
+
     def test_model_kwarg(self):
         widget = ModelSelect2Widget(model=Genre, search_fields=["title__icontains"])
         genre = Genre.objects.last()


### PR DESCRIPTION
I've come across an issue when wanting to use `istartswith` with fields that have spaces. If for example I have an object with name "Space Genre" and use `search_fields = ["name__istartswith"]`, when searching for "Space G" I would expect the object to be returned in the results, but it isn't.

I believe this is down to splitting the search term by white space, and checking the db queries show it is so:

```
WHERE ("testapp_genre"."title" LIKE Space% ESCAPE '\' AND "testapp_genre"."title" LIKE G% ESCAPE '\')
```

In my opinion it'd be better to stop splitting the search term by [white space](https://github.com/dbramwell/django-select2/blob/4afc09d35b0c3a62c97d7baae3d36c71fa0e828f/django_select2/forms.py#L400-L407) and instead just query by the the full string with `select = Q(**{search_fields[0]: term})`, but there is a [test](https://github.com/dbramwell/django-select2/blob/4afc09d35b0c3a62c97d7baae3d36c71fa0e828f/tests/test_forms.py#L445) that fails when using that approach, so I assume that functionality has been added for some reason.

This pull request checks for matching the full term as well as the individual terms, resulting in a query like:
```
WHERE (
  ("testapp_genre"."title" LIKE Space% ESCAPE '\' AND "testapp_genre"."title" LIKE G% ESCAPE '\')
  OR "testapp_genre"."title" LIKE Space G% ESCAPE '\'
)
```

This means that my results now show up and the previous functionality remains intact, however it does mean that genres that start with either "Space" or "G" will also show up, which I'm not sure is intuitive. Maybe it would be better to check if the filter is a `startswith` or `endswith` and avoid splitting the search term for those?

Edit:
I've now taken the above approach, only splitting the search terms by white space when we are using a 'contains' search field, as I think that's the only place it makes sense (might be wrong though)

