### PR TITLE
Prevent crash when a non-numeric value is passed to a ModelSelectField(widget=ModelSelect2Widget(...))

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -331,6 +331,11 @@ class TestModelSelect2Mixin(TestHeavySelect2Mixin):
     def genres(self, genres):
         return genres
 
+    def test_invalid_value(self, genres):
+        genre = genres[0]
+        field = self.form.fields["primary_genre"]
+        field.widget.render("primary_genre", f"{genre.pk}'[0]")
+
     def test_selected_option(self, db, genres):
         genre = genres[0]
         genre2 = genres[1]


### PR DESCRIPTION
If the form value for a ModelSelectField for numeric foreign key is non-numeric, rendering the form
crashes with:

> Field 'id' expected a number but got "13'[0]".

[(full traceback)](https://gist.github.com/jieter/af22e689454daf990dcd4f2a3011da3f)

This proposes ignoring non-numeric values for numeric fields. A small test case is included.