### PR TITLE
Resolve #39 -- Make default search more like Django admin

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -482,7 +482,7 @@ class TestModelSelect2Mixin(TestHeavySelect2Mixin):
         assert qs.exists()
 
         qs = widget.filter_queryset(None, "NOT Gen")
-        assert qs.exists(), "contains works even if only one part matches"
+        assert not qs.exists(), "contains works even if all bits match"
 
     def test_filter_queryset__multiple_fields(self, genres):
         genre = Genre.objects.create(title="Space Genre")


### PR DESCRIPTION
Different to before we now match search terms only if all
bits match or the entire statement. The last part differs
from the behavior in Django admin, which does not inlcude
exact machtes of the entire search term inlcude spaces.

Partially revert 07054b2d8ff15144c6b1b00577f3c898d47712bc