### PR TITLE
Added *.egg-info in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 
-Django_Select2.egg-info
-Django_Select2_Py3.egg-info
+*.egg-info
 dist
 build
 


### PR DESCRIPTION
After running `python setup.py test` the diretory `django_select2.egg-info` is created.

This PR ignore `*.egg-info` dirs.