### PR TITLE
Don't set default_app_config in Django 3.2 up

### DIFF
--- a/django_select2/__init__.py
+++ b/django_select2/__init__.py
@@ -7,4 +7,7 @@ The application includes Select2 driven Django Widgets and Form Fields.
 .. _Select2: https://select2.org/
 
 """
-default_app_config = "django_select2.apps.Select2AppConfig"
+from django import get_version
+
+if get_version() < '3.2':
+    default_app_config = "django_select2.apps.Select2AppConfig"


### PR DESCRIPTION
As of Django 3.2, explicitly setting `default_app_config` [is deprecated](https://docs.djangoproject.com/en/3.2/releases/3.2/#features-deprecated-in-3-2). This check allows django-select2 to continue supporting earlier versions of Django while silencing this deprecation warning. Fixes #97.