### PR TITLE
Fix #163 -- Lazily get i18n locale name

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -86,9 +86,10 @@ class Select2Mixin:
 
     empty_label = ""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.i18n_name = SELECT2_TRANSLATIONS.get(get_language())
+    @property
+    def i18n_name(self):
+        """Name of the i18n file for the current language."""
+        return SELECT2_TRANSLATIONS.get(get_language())
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         """Add select2 data attributes."""

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -3,7 +3,6 @@ import os
 from collections.abc import Iterable
 
 import pytest
-from django.contrib.admin.widgets import SELECT2_TRANSLATIONS
 from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils import translation
@@ -48,11 +47,16 @@ class TestSelect2Mixin:
         assert "my-class" in widget.render("name", None)
         assert "django-select2" in widget.render("name", None)
 
-    @pytest.mark.parametrize("code,name", SELECT2_TRANSLATIONS.items())
-    def test_lang_attr(self, code, name):
-        translation.activate(code)
-        widget = self.widget_cls()
-        assert f'lang="{name}"' in widget.render("name", None)
+    def test_lang_attr(self):
+        with translation.override("de"):
+            widget = Select2Widget()
+            assert 'lang="de"' in widget.render("name", None)
+
+        # Regression test for #163
+        widget = Select2Widget()
+        assert widget.i18n_name == "en"
+        with translation.override("de"):
+            assert widget.i18n_name == "de"
 
     def test_allow_clear(self, db):
         required_field = self.form.fields["artist"]
@@ -258,11 +262,10 @@ class TestHeavySelect2Mixin(TestSelect2Mixin):
             "name", None
         )
 
-    @pytest.mark.parametrize("code,name", SELECT2_TRANSLATIONS.items())
-    def test_lang_attr(self, code, name):
-        translation.activate(code)
-        widget = self.widget_cls(data_view="heavy_data_1")
-        assert f'lang="{name}"' in widget.render("name", None)
+    def test_lang_attr(self):
+        with translation.override("fr"):
+            widget = self.widget_cls(data_view="heavy_data_1")
+            assert 'lang="fr"' in widget.render("name", None)
 
     def test_selected_option(self, db):
         not_required_field = self.form.fields["primary_genre"]


### PR DESCRIPTION
A widget instance can leak the i18n setting to another request
or be stuck on the default language setting.
