### PR TITLE
Allow django_select2.js to be to be hosted elsewhere

### DIFF
--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -55,19 +55,22 @@ class Select2Conf(AppConf):
     It has set `select2_` as a default value, which you can change if needed.
     """
 
-    JS = "admin/js/vendor/select2/select2.full.min.js"
+    JS = [
+        "admin/js/vendor/select2/select2.full.min.js",
+        "django_select2/django_select2.js",
+    ]
     """
-    The URI for the Select2 JS file. By default this points to version shipped with Django.
+    The URI list for the Select2 JS files. By default this points to version shipped with Django.
 
     If you want to select the version of the JS library used, or want to serve it from
     the local 'static' resources, add a line to your settings.py like so::
 
-        SELECT2_JS = 'assets/js/select2.min.js'
+        SELECT2_JS = ['assets/js/jquery.js', 'assets/js/select2.min.js']
 
     If you provide your own JS and would not like Django-Select2 to load any, change
-    this setting to a blank string like so::
+    this setting to a empty list like so::
 
-        SELECT2_JS = ''
+        SELECT2_JS = []
 
     .. tip:: Change this setting to a local asset in your development environment to
         develop without an Internet connection.

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -48,6 +48,7 @@ in their names.
 """
 import operator
 import uuid
+import warnings
 from functools import reduce
 from itertools import chain
 from pickle import PicklingError  # nosec
@@ -127,8 +128,18 @@ class Select2Mixin:
         .. Note:: For more information visit
             https://docs.djangoproject.com/en/stable/topics/forms/media/#media-as-a-dynamic-property
         """
-        select2_js = [settings.SELECT2_JS] if settings.SELECT2_JS else []
+        select2_js = settings.SELECT2_JS[:] if settings.SELECT2_JS else []
         select2_css = settings.SELECT2_CSS if settings.SELECT2_CSS else []
+
+        if isinstance(select2_js, str):
+            warnings.warn(
+                (
+                    "SELECT2_JS='%(value)s' settings is deprecated, "
+                    "use SELECT2_JS=['%(value)s'] instead."
+                ) % {'value': select2_js},
+                stacklevel=2
+            )
+            select2_js = [select2_js]
 
         if isinstance(select2_css, str):
             select2_css = [select2_css]
@@ -138,7 +149,7 @@ class Select2Mixin:
             i18n_file = [f"{settings.SELECT2_I18N_PATH}/{self.i18n_name}.js"]
 
         return forms.Media(
-            js=select2_js + i18n_file + ["django_select2/django_select2.js"],
+            js=select2_js + i18n_file,
             css={"screen": select2_css + ["django_select2/django_select2.css"]},
         )
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -135,15 +135,15 @@ class TestSelect2Mixin:
         translation.activate("de")
         assert tuple(Select2Widget().media._js) == (
             "admin/js/vendor/select2/select2.full.min.js",
-            "admin/js/vendor/select2/i18n/de.js",
             "django_select2/django_select2.js",
+            "admin/js/vendor/select2/i18n/de.js",
         )
 
         translation.activate("en")
         assert tuple(Select2Widget().media._js) == (
             "admin/js/vendor/select2/select2.full.min.js",
-            "admin/js/vendor/select2/i18n/en.js",
             "django_select2/django_select2.js",
+            "admin/js/vendor/select2/i18n/en.js",
         )
 
         translation.activate("00")
@@ -155,8 +155,8 @@ class TestSelect2Mixin:
         translation.activate("sr-Cyrl")
         assert tuple(Select2Widget().media._js) == (
             "admin/js/vendor/select2/select2.full.min.js",
-            "admin/js/vendor/select2/i18n/sr-Cyrl.js",
             "django_select2/django_select2.js",
+            "admin/js/vendor/select2/i18n/sr-Cyrl.js",
         )
 
         pytest.importorskip("django", minversion="2.0.4")
@@ -164,15 +164,15 @@ class TestSelect2Mixin:
         translation.activate("zh-hans")
         assert tuple(Select2Widget().media._js) == (
             "admin/js/vendor/select2/select2.full.min.js",
-            "admin/js/vendor/select2/i18n/zh-CN.js",
             "django_select2/django_select2.js",
+            "admin/js/vendor/select2/i18n/zh-CN.js",
         )
 
         translation.activate("zh-hant")
         assert tuple(Select2Widget().media._js) == (
             "admin/js/vendor/select2/select2.full.min.js",
-            "admin/js/vendor/select2/i18n/zh-TW.js",
             "django_select2/django_select2.js",
+            "admin/js/vendor/select2/i18n/zh-TW.js",
         )
 
     def test_theme_setting(self, settings):
@@ -186,8 +186,8 @@ class TestSelect2AdminMixin:
         translation.activate("en")
         assert tuple(Select2AdminMixin().media._js) == (
             "admin/js/vendor/select2/select2.full.min.js",
-            "admin/js/vendor/select2/i18n/en.js",
             "django_select2/django_select2.js",
+            "admin/js/vendor/select2/i18n/en.js",
         )
 
         assert dict(Select2AdminMixin().media._css) == {
@@ -208,7 +208,7 @@ class TestSelect2MixinSettings:
         assert "django_select2/django_select2.js" in result
 
     def test_js_setting(self, settings):
-        settings.SELECT2_JS = "alternate.js"
+        settings.SELECT2_JS = ["alternate.js", "django_select2/django_select2.js"]
         sut = Select2Widget()
         result = sut.media.render()
         assert "alternate.js" in result
@@ -218,7 +218,7 @@ class TestSelect2MixinSettings:
         settings.SELECT2_JS = ""
         sut = Select2Widget()
         result = sut.media.render()
-        assert "django_select2/django_select2.js" in result
+        assert "django_select2/django_select2.js" not in result
 
     def test_css_setting(self, settings):
         settings.SELECT2_CSS = "alternate.css"


### PR DESCRIPTION
Continue PR #18 

- Does the order of `i18n_file` and `django_select2.js `matter?
- If `SELECT2_JS` is empty, should i18n file be considered?