### PR TITLE
Add monthly downloads badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 Django-Select2
 ==============
 
-|version| |coverage| |license|
+|version| |coverage| |license| |monthly-downloads|
 
 Custom autocomplete fields for `Django`_.
 
@@ -29,3 +29,6 @@ Documentation available at https://django-select2.readthedocs.io/.
    :target: https://codecov.io/gh/codingjoe/django-select2
 .. |license| image:: https://img.shields.io/badge/license-APL2-blue.svg
    :target: https://raw.githubusercontent.com/codingjoe/django-select2/master/LICENSE.txt
+.. |monthly-downloads| image:: https://assets.piptrends.com/get-last-month-downloads-badge/django-select2.svg
+    :alt: django-select2 Downloads Last Month by pip Trends
+    :target: https://piptrends.com/package/django-select2


### PR DESCRIPTION
This PR is to add a monthly downloads badge that we have been building at pip Trends, a learning forum that we are trying to build for all Python developers. 
This PR is solely to share something we have built and if needed, the link to the package's pip Trends page can be removed from the badge. 

You can view more at - https://piptrends.com/package/django-select2