### PR TITLE
Fix #292 -- Change admin widgets' JS media ordering

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -155,7 +155,7 @@ class Select2Mixin:
             i18n_file = [f"{settings.SELECT2_I18N_PATH}/{self.i18n_name}.js"]
 
         return forms.Media(
-            js=select2_js + i18n_file + ["django_select2/django_select2.js"],
+            js=select2_js + i18n_file + ["admin/js/jquery.init.js"] + ["django_select2/django_select2.js"],
             css={"screen": select2_css + ["django_select2/django_select2.css"]},
         )
 

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -155,7 +155,7 @@ class Select2Mixin:
             i18n_file = [f"{settings.SELECT2_I18N_PATH}/{self.i18n_name}.js"]
 
         return forms.Media(
-            js=select2_js + i18n_file + ["admin/js/jquery.init.js"] + ["django_select2/django_select2.js"],
+            js=select2_js + i18n_file + ["admin/js/jquery.init.js", "django_select2/django_select2.js"],
             css={"screen": select2_css + ["django_select2/django_select2.css"]},
         )
 

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -155,9 +155,7 @@ class Select2Mixin:
             i18n_file = [f"{settings.SELECT2_I18N_PATH}/{self.i18n_name}.js"]
 
         return forms.Media(
-            js=select2_js
-            + i18n_file
-            + ["admin/js/jquery.init.js", "django_select2/django_select2.js"],
+            js=select2_js + i18n_file + ["django_select2/django_select2.js"],
             css={"screen": select2_css + ["django_select2/django_select2.css"]},
         )
 
@@ -171,8 +169,12 @@ class Select2AdminMixin:
     def media(self):
         css = {**AutocompleteMixin(None, None).media._css}
         css["screen"].append("django_select2/django_select2.css")
+        js = [*Select2Mixin().media._js]
+        js.insert(
+            js.index("django_select2/django_select2.js"), "admin/js/jquery.init.js"
+        )
         return forms.Media(
-            js=Select2Mixin().media._js,
+            js=js,
             css=css,
         )
 

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -155,7 +155,9 @@ class Select2Mixin:
             i18n_file = [f"{settings.SELECT2_I18N_PATH}/{self.i18n_name}.js"]
 
         return forms.Media(
-            js=select2_js + i18n_file + ["admin/js/jquery.init.js", "django_select2/django_select2.js"],
+            js=select2_js
+            + i18n_file
+            + ["admin/js/jquery.init.js", "django_select2/django_select2.js"],
             css={"screen": select2_css + ["django_select2/django_select2.css"]},
         )
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -188,6 +188,7 @@ class TestSelect2AdminMixin:
         assert tuple(Select2AdminMixin().media._js) == (
             "admin/js/vendor/select2/select2.full.min.js",
             "admin/js/vendor/select2/i18n/en.js",
+            "admin/js/jquery.init.js",
             "django_select2/django_select2.js",
         )
 


### PR DESCRIPTION
Select2Mixin now loads admin/js/jquery.init.js, just like the AutocompleteMixin of Django Admin. Fixes #292.