### PR TITLE
Add support for selects added dynamically in the Django admin

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -69,6 +69,30 @@
 
   $(function () {
     $('.django-select2').djangoSelect2()
+
+    // This part fixes new inlines not having the correct select2 widgets
+    function handleFormsetAdded(row, formsetName) {
+      // Converting to the "normal jQuery"
+      var jqRow = django.jQuery(row)
+
+      // Because select2 was already instantiated on the empty form, we need to remove it, destroy the instance,
+      // and re-instantiate it.
+      jqRow.find('.select2-container').remove()
+      jqRow.find('.django-select2').djangoSelect2('destroy');
+      jqRow.find('.django-select2').djangoSelect2()
+    }
+
+    // See: https://docs.djangoproject.com/en/dev/ref/contrib/admin/javascript/#supporting-versions-of-django-older-than-4-1
+    django.jQuery(document).on('formset:added', function (event, $row, formsetName) {
+      if (event.detail && event.detail.formsetName) {
+          // Django >= 4.1
+          handleFormsetAdded(event.target, event.detail.formsetName)
+      } else {
+          // Django < 4.1, use $row and formsetName
+          handleFormsetAdded($row.get(0), formsetName)
+      }
+    })
+    // End of fix
   })
 
   return $.fn.djangoSelect2

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -77,7 +77,7 @@
 
       // Because select2 was already instantiated on the empty form, we need to remove it, destroy the instance,
       // and re-instantiate it.
-      jqRow.find('.select2-container').remove()
+      jqRow.find('.django-select2').parent().find('.select2-container').remove()
       jqRow.find('.django-select2').djangoSelect2('destroy');
       jqRow.find('.django-select2').djangoSelect2()
     }


### PR DESCRIPTION
As described in #249 and #297 django-select2 does not currently work with selects added dynamically in the Django admin. 

The solution was implemented in #249 and all credit should go to Jurrian Tromp. I only added a small correction:

```diff
- jqRow.find('.select2-container').remove()
+ jqRow.find('.django-select2').parent().find('.select2-container').remove()
```

to only remove `.select2-container` when it is a sibling of `.django-select2`. Otherwise the wrong `.select2-container` might get deleted.