### PR TITLE
Fix dependent fields in a formset

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -26,9 +26,16 @@
 
           let dependentFields = $element.data('select2-dependent-fields')
           if (dependentFields) {
+            const find_element = function(selector) {
+              const result = $(selector, $element.closest(':has(' + selector + ')'))
+              if (result.length > 0) return result
+              else return null
+            }
             dependentFields = dependentFields.trim().split(/\s+/)
             $.each(dependentFields, function (i, dependentField) {
-              result[dependentField] = $('[name=' + dependentField + ']', $element.closest('form')).val()
+              const name_is = '[name=' + dependentField + ']'
+              const name_ends_with = '[name$=' + dependentField + ']'
+              result[dependentField] = (find_element(name_is) || find_element(name_ends_with)).val()
             })
           }
 

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -34,7 +34,7 @@
             dependentFields = dependentFields.trim().split(/\s+/)
             $.each(dependentFields, function (i, dependentField) {
               const nameIs = `[name=${dependentField}]`
-              const nameEndsWith = `[name$=${dependentField}]`
+              const nameEndsWith = `[name$=-${dependentField}]`
               result[dependentField] = (findElement(nameIs) || findElement(nameEndsWith)).val()
             })
           }

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -26,16 +26,16 @@
 
           let dependentFields = $element.data('select2-dependent-fields')
           if (dependentFields) {
-            const find_element = function(selector) {
+            const findElement = function (selector) {
               const result = $(selector, $element.closest(':has(' + selector + ')'))
               if (result.length > 0) return result
               else return null
             }
             dependentFields = dependentFields.trim().split(/\s+/)
             $.each(dependentFields, function (i, dependentField) {
-              const name_is = '[name=' + dependentField + ']'
-              const name_ends_with = '[name$=' + dependentField + ']'
-              result[dependentField] = (find_element(name_is) || find_element(name_ends_with)).val()
+              const nameIs = '[name=' + dependentField + ']'
+              const nameEndsWith = '[name$=' + dependentField + ']'
+              result[dependentField] = (findElement(nameIs) || findElement(nameEndsWith)).val()
             })
           }
 

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -27,14 +27,14 @@
           let dependentFields = $element.data('select2-dependent-fields')
           if (dependentFields) {
             const findElement = function (selector) {
-              const result = $(selector, $element.closest(':has(' + selector + ')'))
+              const result = $(selector, $element.closest(`:has(${selector})`))
               if (result.length > 0) return result
               else return null
             }
             dependentFields = dependentFields.trim().split(/\s+/)
             $.each(dependentFields, function (i, dependentField) {
-              const nameIs = '[name=' + dependentField + ']'
-              const nameEndsWith = '[name$=' + dependentField + ']'
+              const nameIs = `[name=${dependentField}]`
+              const nameEndsWith = `[name$=${dependentField}]`
               result[dependentField] = (findElement(nameIs) || findElement(nameEndsWith)).val()
             })
           }


### PR DESCRIPTION
This PR provides a general solution for #136 based on the solution by @rez0n.

The contributions of this solution are the following:

- Find the closest common ancestor of two chained selects instead of assuming it is a form.
- Try to find the dependent field by its name attribute using a two-fold search strategy: exact match otherwise ends with