### PR TITLE
Fix dependent fields with checkbox

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -35,7 +35,12 @@
             $.each(dependentFields, function (i, dependentField) {
               const nameIs = `[name=${dependentField}]`
               const nameEndsWith = `[name$=-${dependentField}]`
-              result[dependentField] = (findElement(nameIs) || findElement(nameEndsWith)).val()
+              const field = (findElement(nameIs) || findElement(nameEndsWith))
+              if (field.is(":checkbox")) {
+                result[dependentField] = field.prop("checked") ? "1" : "0"
+              } else {
+                result[dependentField] = field.val()
+              }
             })
           }
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -844,6 +844,49 @@ class TestAddressChainedSelect2Widget:
         )
         assert city2_container.text == ""
 
+    @pytest.mark.selenium
+    def test_dependent_fields_using_checkbox(
+        self, db, live_server, driver, cities
+    ):
+        driver.get(live_server + self.url)
+        (
+            country_container,
+            city_container,
+            city2_container,
+        ) = driver.find_elements(By.CSS_SELECTOR, ".select2-selection--single")
+
+        # selecting a country really does it
+        city_container.click()
+        WebDriverWait(driver, 60).until(
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, ".select2-results li")
+            )
+        )
+        city_option = driver.find_element(
+            By.CSS_SELECTOR, ".select2-results li"
+        )
+        city_name = city_option.text
+        city_option.click()
+        assert city_name == city_container.text
+
+        # check active to false
+        active_checkbox = driver.find_element(
+            By.ID, 'id_active'
+        )
+        active_checkbox.click()
+
+        # check the value in city
+        city_container.click()
+        WebDriverWait(driver, 60).until(
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, ".select2-results li")
+            )
+        )
+        city_option = driver.find_element(
+            By.CSS_SELECTOR, ".select2-results li"
+        )
+        assert city_option.text == "No results found"
+
 
 @pytest.fixture(
     name="widget",

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -209,7 +209,7 @@ class AddressChainedSelect2WidgetForm(forms.Form):
         label="City",
         widget=ModelSelect2Widget(
             search_fields=["name__icontains"],
-            dependent_fields={"country": "country"},
+            dependent_fields={"country": "country", "active": "active"},
             max_results=500,
             attrs={"data-minimum-input-length": 0},
         ),
@@ -225,6 +225,8 @@ class AddressChainedSelect2WidgetForm(forms.Form):
             attrs={"data-minimum-input-length": 0},
         ),
     )
+
+    active = forms.BooleanField(required=False, initial=True)
 
 
 class GroupieForm(forms.ModelForm):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -59,6 +59,7 @@ class City(models.Model):
     country = models.ForeignKey(
         "Country", related_name="cities", on_delete=models.CASCADE
     )
+    active = models.BooleanField(default=True, blank=True)
 
     class Meta:
         ordering = ("name",)


### PR DESCRIPTION
Fix #289 

- My Selenium tests don't work correctly. I'm not sure if I implemented the test in the best possible way
- The value of the related field that goes to the backend is `1` or `0`, django understands boolean fields this way.